### PR TITLE
Feature/13 date monthly

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:daily_receipt/models/calendar.dart';
 import 'package:daily_receipt/models/todos.dart';
 import 'package:daily_receipt/screens/todos.dart';
 import 'package:flutter/material.dart';
@@ -6,12 +7,13 @@ import 'package:provider/provider.dart';
 import './theme.dart';
 
 void main() {
-  runApp(
-    ChangeNotifierProvider(
-      create: (context) => Todos(),
-      child: const MyApp(),
-    ),
-  );
+  runApp(MultiProvider(
+    providers: [
+      ChangeNotifierProvider(create: (context) => Todos()),
+      ChangeNotifierProvider(create: (context) => Calendar()),
+    ],
+    child: const MyApp(),
+  ));
 }
 
 class MyApp extends StatelessWidget {

--- a/lib/models/calendar.dart
+++ b/lib/models/calendar.dart
@@ -4,7 +4,7 @@ class Calendar extends ChangeNotifier {
   DateTime now = DateTime.now().toUtc();
   late DateTime _selectedDate = DateTime.utc(now.year, now.month, now.day);
 
-  DateTime get selectedDate => _selectedDate.toLocal();
+  DateTime get selectedDate => _selectedDate;
 
   void selectDate(DateTime date) {
     _selectedDate = date;

--- a/lib/models/calendar.dart
+++ b/lib/models/calendar.dart
@@ -4,7 +4,7 @@ class Calendar extends ChangeNotifier {
   DateTime now = DateTime.now().toUtc();
   late DateTime _selectedDate = DateTime.utc(now.year, now.month, now.day);
 
-  DateTime get selectedDate => _selectedDate;
+  DateTime get selectedDate => _selectedDate.toLocal();
 
   void selectDate(DateTime date) {
     _selectedDate = date;

--- a/lib/models/calendar.dart
+++ b/lib/models/calendar.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class Calendar extends ChangeNotifier {
+  DateTime now = DateTime.now().toUtc();
+  late DateTime _selectedDate = DateTime.utc(now.year, now.month, now.day);
+
+  DateTime get selectedDate => _selectedDate;
+
+  void selectDate(DateTime date) {
+    _selectedDate = date;
+    notifyListeners();
+  }
+}

--- a/lib/models/todos.dart
+++ b/lib/models/todos.dart
@@ -18,6 +18,7 @@ class Todo {
 
   final DateTime createdAt;
   DateTime? completedAt;
+  DateTime scheduledDate;
 
   Todo({
     required this.id,
@@ -25,5 +26,6 @@ class Todo {
     this.isDone = false,
     required this.createdAt,
     this.completedAt,
+    required this.scheduledDate,
   });
 }

--- a/lib/models/todos.dart
+++ b/lib/models/todos.dart
@@ -17,7 +17,7 @@ class Todos extends ChangeNotifier {
   Map<DateTime, List<Todo>> groupTodosByDate(List<Todo> todos) {
     Map<DateTime, List<Todo>> grouped = {};
 
-    for (var todo in todos) {
+    for (Todo todo in todos) {
       DateTime date = todo.scheduledDate;
       if (!grouped.containsKey(date)) {
         grouped[date] = [];

--- a/lib/models/todos.dart
+++ b/lib/models/todos.dart
@@ -5,9 +5,27 @@ class Todos extends ChangeNotifier {
 
   List<Todo> get todos => _todos;
 
+  Map<DateTime, List<Todo>> get groupedTodosByDate {
+    return groupTodosByDate(_todos);
+  }
+
   void add(Todo todo) {
     _todos.add(todo);
     notifyListeners();
+  }
+
+  Map<DateTime, List<Todo>> groupTodosByDate(List<Todo> todos) {
+    Map<DateTime, List<Todo>> grouped = {};
+
+    for (var todo in todos) {
+      DateTime date = todo.scheduledDate;
+      if (!grouped.containsKey(date)) {
+        grouped[date] = [];
+      }
+      grouped[date]!.add(todo);
+    }
+
+    return grouped;
   }
 }
 

--- a/lib/screens/todos.dart
+++ b/lib/screens/todos.dart
@@ -1,4 +1,5 @@
 import 'package:daily_receipt/models/todos.dart';
+import 'package:daily_receipt/widgets/calendar_dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -28,6 +29,13 @@ class TodosScreen extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 24),
         child: Column(
           children: [
+            IconButton(
+              onPressed: () => showDialog(
+                  context: context,
+                  builder: (context) => const CalendarDialog()),
+              icon: const Icon(Icons.calendar_month_rounded),
+              color: Theme.of(context).colorScheme.secondary,
+            ),
             TextField(
               controller: controller,
               style: Theme.of(context).textTheme.bodyMedium?.copyWith(

--- a/lib/screens/todos.dart
+++ b/lib/screens/todos.dart
@@ -2,6 +2,7 @@ import 'package:daily_receipt/models/calendar.dart';
 import 'package:daily_receipt/models/todos.dart';
 import 'package:daily_receipt/widgets/calendar_dialog.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 class TodosScreen extends StatelessWidget {
@@ -11,7 +12,7 @@ class TodosScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final TextEditingController controller = TextEditingController();
     final Todos todosProvider = Provider.of<Todos>(context, listen: false);
-    final calendarProvider = Provider.of<Calendar>(context, listen: false);
+    final calendarProvider = Provider.of<Calendar>(context, listen: true);
 
     void addTodo() {
       if (controller.text.isEmpty) return;
@@ -32,12 +33,27 @@ class TodosScreen extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 24),
         child: Column(
           children: [
-            IconButton(
-              onPressed: () => showDialog(
-                  context: context,
-                  builder: (context) => const CalendarDialog()),
-              icon: const Icon(Icons.calendar_month_rounded),
-              color: Theme.of(context).colorScheme.secondary,
+            const SizedBox(height: 20),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  DateFormat('MMMM')
+                      .format(calendarProvider.selectedDate)
+                      .toString(),
+                  style: Theme.of(context).textTheme.headlineLarge?.copyWith(
+                        color: Theme.of(context).colorScheme.onBackground,
+                      ),
+                ),
+                IconButton(
+                  onPressed: () => showDialog(
+                      context: context,
+                      builder: (context) => const CalendarDialog()),
+                  icon: const Icon(Icons.calendar_month_rounded),
+                  iconSize: 28,
+                  color: Theme.of(context).colorScheme.secondary,
+                ),
+              ],
             ),
             TextField(
               controller: controller,

--- a/lib/screens/todos.dart
+++ b/lib/screens/todos.dart
@@ -1,3 +1,4 @@
+import 'package:daily_receipt/models/calendar.dart';
 import 'package:daily_receipt/models/todos.dart';
 import 'package:daily_receipt/widgets/calendar_dialog.dart';
 import 'package:flutter/material.dart';
@@ -10,6 +11,7 @@ class TodosScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final TextEditingController controller = TextEditingController();
     final Todos todosProvider = Provider.of<Todos>(context, listen: false);
+    final calendarProvider = Provider.of<Calendar>(context, listen: false);
 
     void addTodo() {
       if (controller.text.isEmpty) return;
@@ -18,6 +20,7 @@ class TodosScreen extends StatelessWidget {
         id: todosProvider.todos.length,
         content: controller.text,
         createdAt: DateTime.now().toUtc(),
+        scheduledDate: calendarProvider.selectedDate,
       );
 
       todosProvider.add(newTodo);

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -24,9 +24,10 @@ class AppTheme {
   );
 
   static TextTheme textTheme = TextTheme(
-    headlineLarge: GoogleFonts.gothicA1(
-      fontSize: 28,
+    headlineLarge: GoogleFonts.courierPrime(
+      fontSize: 32,
       fontWeight: FontWeight.bold,
+      letterSpacing: -1,
     ),
     titleLarge: GoogleFonts.courierPrime(
       fontSize: 24,

--- a/lib/widgets/calendar_dialog.dart
+++ b/lib/widgets/calendar_dialog.dart
@@ -28,7 +28,7 @@ class CalendarDialog extends StatelessWidget {
               calendarProvider.selectDate(selectedDay);
             },
             selectedDayPredicate: (day) {
-              return isSameDay(calendarProvider.selectedDate, day);
+              return isSameDay(calendarProvider.selectedDate, day.toLocal());
             },
             headerStyle: HeaderStyle(
               formatButtonVisible: false,

--- a/lib/widgets/calendar_dialog.dart
+++ b/lib/widgets/calendar_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:table_calendar/table_calendar.dart';
 
 class CalendarDialog extends StatelessWidget {
@@ -16,6 +17,23 @@ class CalendarDialog extends StatelessWidget {
           lastDay: DateTime.utc(2034, 12, 31),
           focusedDay: DateTime.now(),
           calendarFormat: CalendarFormat.month,
+          headerStyle: HeaderStyle(
+            formatButtonVisible: false,
+            titleCentered: true,
+            titleTextFormatter: (date, locale) {
+              return DateFormat('yyyy.MM.').format(date.toLocal()).toString();
+            },
+            titleTextStyle: Theme.of(context).textTheme.titleLarge!,
+            headerPadding: const EdgeInsets.only(top: 4, bottom: 12),
+            leftChevronIcon: Icon(
+              Icons.chevron_left,
+              color: Theme.of(context).colorScheme.secondary,
+            ),
+            rightChevronIcon: Icon(
+              Icons.chevron_right,
+              color: Theme.of(context).colorScheme.secondary,
+            ),
+          ),
         ),
       ),
     );

--- a/lib/widgets/calendar_dialog.dart
+++ b/lib/widgets/calendar_dialog.dart
@@ -53,7 +53,7 @@ class CalendarDialog extends StatelessWidget {
                 color: Theme.of(context).colorScheme.onPrimary,
               ),
               todayDecoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.primary,
+                color: Theme.of(context).colorScheme.secondary,
                 shape: BoxShape.circle,
               ),
               selectedTextStyle: TextStyle(

--- a/lib/widgets/calendar_dialog.dart
+++ b/lib/widgets/calendar_dialog.dart
@@ -10,29 +10,44 @@ class CalendarDialog extends StatelessWidget {
     return Dialog(
       backgroundColor: Theme.of(context).colorScheme.surface,
       surfaceTintColor: Theme.of(context).colorScheme.surface,
+      insetPadding: const EdgeInsets.symmetric(horizontal: 20.0),
       child: Padding(
         padding: const EdgeInsets.all(12.0),
-        child: TableCalendar(
-          firstDay: DateTime.utc(2023, 1, 1),
-          lastDay: DateTime.utc(2034, 12, 31),
-          focusedDay: DateTime.now(),
-          calendarFormat: CalendarFormat.month,
-          headerStyle: HeaderStyle(
-            formatButtonVisible: false,
-            titleCentered: true,
-            titleTextFormatter: (date, locale) {
-              return DateFormat('yyyy.MM.').format(date.toLocal()).toString();
-            },
-            titleTextStyle: Theme.of(context).textTheme.titleLarge!,
-            headerPadding: const EdgeInsets.only(top: 4, bottom: 12),
-            leftChevronIcon: Icon(
-              Icons.chevron_left,
-              color: Theme.of(context).colorScheme.secondary,
+        child: SizedBox(
+          height: 420,
+          child: TableCalendar(
+            firstDay: DateTime.utc(2023, 1, 1),
+            lastDay: DateTime.utc(2034, 12, 31),
+            focusedDay: DateTime.now(),
+            calendarFormat: CalendarFormat.month,
+            headerStyle: HeaderStyle(
+              formatButtonVisible: false,
+              titleCentered: true,
+              titleTextFormatter: (date, locale) {
+                return DateFormat('yyyy.MM.').format(date.toLocal()).toString();
+              },
+              titleTextStyle: Theme.of(context).textTheme.titleLarge!,
+              headerPadding: const EdgeInsets.only(top: 6, bottom: 6),
+              leftChevronIcon: Icon(
+                Icons.chevron_left,
+                color: Theme.of(context).colorScheme.secondary,
+              ),
+              rightChevronIcon: Icon(
+                Icons.chevron_right,
+                color: Theme.of(context).colorScheme.secondary,
+              ),
             ),
-            rightChevronIcon: Icon(
-              Icons.chevron_right,
-              color: Theme.of(context).colorScheme.secondary,
+            calendarStyle: CalendarStyle(
+              tablePadding: const EdgeInsets.all(8),
+              todayTextStyle: TextStyle(
+                color: Theme.of(context).colorScheme.onPrimary,
+              ),
+              todayDecoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.primary,
+                shape: BoxShape.circle,
+              ),
             ),
+            daysOfWeekHeight: 30,
           ),
         ),
       ),

--- a/lib/widgets/calendar_dialog.dart
+++ b/lib/widgets/calendar_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:table_calendar/table_calendar.dart';
 
 class CalendarDialog extends StatelessWidget {
   const CalendarDialog({super.key});
@@ -6,8 +7,17 @@ class CalendarDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Dialog(
-      child: Text('dialog'),
       backgroundColor: Theme.of(context).colorScheme.surface,
+      surfaceTintColor: Theme.of(context).colorScheme.surface,
+      child: Padding(
+        padding: const EdgeInsets.all(12.0),
+        child: TableCalendar(
+          firstDay: DateTime.utc(2023, 1, 1),
+          lastDay: DateTime.utc(2034, 12, 31),
+          focusedDay: DateTime.now(),
+          calendarFormat: CalendarFormat.month,
+        ),
+      ),
     );
   }
 }

--- a/lib/widgets/calendar_dialog.dart
+++ b/lib/widgets/calendar_dialog.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class CalendarDialog extends StatelessWidget {
+  const CalendarDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      child: Text('dialog'),
+      backgroundColor: Theme.of(context).colorScheme.surface,
+    );
+  }
+}

--- a/lib/widgets/calendar_dialog.dart
+++ b/lib/widgets/calendar_dialog.dart
@@ -26,6 +26,7 @@ class CalendarDialog extends StatelessWidget {
             calendarFormat: CalendarFormat.month,
             onDaySelected: (selectedDay, focusedDay) {
               calendarProvider.selectDate(selectedDay);
+              Navigator.pop(context);
             },
             selectedDayPredicate: (day) {
               return isSameDay(calendarProvider.selectedDate, day.toLocal());

--- a/lib/widgets/calendar_dialog.dart
+++ b/lib/widgets/calendar_dialog.dart
@@ -1,5 +1,7 @@
+import 'package:daily_receipt/models/calendar.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
 import 'package:table_calendar/table_calendar.dart';
 
 class CalendarDialog extends StatelessWidget {
@@ -7,6 +9,8 @@ class CalendarDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final calendarProvider = Provider.of<Calendar>(context, listen: false);
+
     return Dialog(
       backgroundColor: Theme.of(context).colorScheme.surface,
       surfaceTintColor: Theme.of(context).colorScheme.surface,
@@ -18,8 +22,14 @@ class CalendarDialog extends StatelessWidget {
           child: TableCalendar(
             firstDay: DateTime.utc(2023, 1, 1),
             lastDay: DateTime.utc(2034, 12, 31),
-            focusedDay: DateTime.now(),
+            focusedDay: calendarProvider.selectedDate,
             calendarFormat: CalendarFormat.month,
+            onDaySelected: (selectedDay, focusedDay) {
+              calendarProvider.selectDate(selectedDay);
+            },
+            selectedDayPredicate: (day) {
+              return isSameDay(calendarProvider.selectedDate, day);
+            },
             headerStyle: HeaderStyle(
               formatButtonVisible: false,
               titleCentered: true,
@@ -43,6 +53,13 @@ class CalendarDialog extends StatelessWidget {
                 color: Theme.of(context).colorScheme.onPrimary,
               ),
               todayDecoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.primary,
+                shape: BoxShape.circle,
+              ),
+              selectedTextStyle: TextStyle(
+                color: Theme.of(context).colorScheme.onPrimary,
+              ),
+              selectedDecoration: BoxDecoration(
                 color: Theme.of(context).colorScheme.primary,
                 shape: BoxShape.circle,
               ),

--- a/lib/widgets/calendar_dialog.dart
+++ b/lib/widgets/calendar_dialog.dart
@@ -22,20 +22,20 @@ class CalendarDialog extends StatelessWidget {
           child: TableCalendar(
             firstDay: DateTime.utc(2023, 1, 1),
             lastDay: DateTime.utc(2034, 12, 31),
-            focusedDay: calendarProvider.selectedDate,
+            focusedDay: calendarProvider.selectedDate.toLocal(),
             calendarFormat: CalendarFormat.month,
             onDaySelected: (selectedDay, focusedDay) {
               calendarProvider.selectDate(selectedDay);
               Navigator.pop(context);
             },
             selectedDayPredicate: (day) {
-              return isSameDay(calendarProvider.selectedDate, day.toLocal());
+              return isSameDay(calendarProvider.selectedDate, day);
             },
             headerStyle: HeaderStyle(
               formatButtonVisible: false,
               titleCentered: true,
               titleTextFormatter: (date, locale) {
-                return DateFormat('yyyy.MM.').format(date.toLocal()).toString();
+                return DateFormat('yyyy.MM.').format(date).toString();
               },
               titleTextStyle: Theme.of(context).textTheme.titleLarge!,
               headerPadding: const EdgeInsets.only(top: 6, bottom: 6),

--- a/lib/widgets/calendar_dialog.dart
+++ b/lib/widgets/calendar_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:daily_receipt/models/calendar.dart';
+import 'package:daily_receipt/models/todos.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
@@ -10,6 +11,7 @@ class CalendarDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final calendarProvider = Provider.of<Calendar>(context, listen: false);
+    final todosProvider = Provider.of<Todos>(context, listen: false);
 
     return Dialog(
       backgroundColor: Theme.of(context).colorScheme.surface,
@@ -30,6 +32,11 @@ class CalendarDialog extends StatelessWidget {
             },
             selectedDayPredicate: (day) {
               return isSameDay(calendarProvider.selectedDate, day);
+            },
+            eventLoader: (day) {
+              return todosProvider.groupedTodosByDate[day] != null
+                  ? [true]
+                  : [];
             },
             headerStyle: HeaderStyle(
               formatButtonVisible: false,
@@ -62,6 +69,14 @@ class CalendarDialog extends StatelessWidget {
               ),
               selectedDecoration: BoxDecoration(
                 color: Theme.of(context).colorScheme.primary,
+                shape: BoxShape.circle,
+              ),
+              markersAnchor: 4,
+              markersAlignment: Alignment.topRight,
+              markerMargin: const EdgeInsets.only(right: 5),
+              markerSize: 8,
+              markerDecoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.tertiary,
                 shape: BoxShape.circle,
               ),
             ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -206,10 +206,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.18.1"
   io:
     dependency: transitive
     description:
@@ -434,6 +434,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  simple_gesture_detector:
+    dependency: transitive
+    description:
+      name: simple_gesture_detector
+      sha256: "86d08f85f1f58583b7b4b941d989f48ea6ce08c1724a1d10954a277c2ec36592"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -495,6 +503,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.1"
+  table_calendar:
+    dependency: "direct main"
+    description:
+      name: table_calendar
+      sha256: "1e3521a3e6d3fc7f645a58b135ab663d458ab12504f1ea7f9b4b81d47086c478"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.9"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,8 @@ dependencies:
   cupertino_icons: ^1.0.2
   google_fonts: ^6.1.0
   provider: ^6.1.1
-  intl: ^0.19.0
+  intl: ^0.18.0
+  table_calendar: ^3.0.9
 
 dev_dependencies:
   flutter_test:

--- a/test/models/calendar_test.dart
+++ b/test/models/calendar_test.dart
@@ -1,0 +1,16 @@
+import 'package:daily_receipt/models/calendar.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('calendar Provider', () {
+    var calendarProvider = Calendar();
+
+    test('인자로 넘긴 날짜가 selectedDate로 설정됩니다.', () {
+      var selectedDate = DateTime(2024, 1, 1);
+
+      calendarProvider.selectDate(selectedDate);
+
+      expect(calendarProvider.selectedDate, selectedDate);
+    });
+  });
+}

--- a/test/models/todos_test.dart
+++ b/test/models/todos_test.dart
@@ -10,6 +10,7 @@ void main() {
         id: todosProvider.todos.length,
         content: 'test',
         createdAt: DateTime.now().toUtc(),
+        scheduledDate: DateTime(2024, 1, 1),
       );
 
       todosProvider.add(newTodo);

--- a/test/models/todos_test.dart
+++ b/test/models/todos_test.dart
@@ -17,5 +17,24 @@ void main() {
 
       expect(todosProvider.todos.contains(newTodo), true);
     });
+
+    test('todos를 날짜별로 그룹화하여 Map으로 반환합니다.', () {
+      final existsDate = DateTime(2024, 1, 1);
+      final notExistsDate = DateTime(2024, 1, 2);
+      var todos = [
+        Todo(
+          id: 1,
+          content: 'test',
+          createdAt: DateTime.now().toUtc(),
+          scheduledDate: existsDate,
+        )
+      ];
+
+      var groupedTodos = todosProvider.groupTodosByDate(todos);
+
+      expect(groupedTodos[existsDate]?.length, 1);
+      expect(groupedTodos[existsDate]?.first, equals(todos[0]));
+      expect(groupedTodos[notExistsDate], null);
+    });
   });
 }


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
> 연관 이슈:  #13

월간 캘린더를 구현합니다. 

## 어떻게 해결했나요?
- 캘린더 dialog(모달) 구현
- [Provider](https://pub.dev/packages/provider)를 이용한 calendar(selectedDate) 상태 관리
- selectedDate가 todo 생성시 scheduledDate로 반영되도록 구현
- calendar에 todo 있는 날을 표시하기 위해 todos를 날짜별로 그룹화 (groupTodosByDate)
- calendar에 custom 스타일 적용
- todo 페이지 상단에 선택된 날의 월을 영어로 표시

### 미리보기
<img width="288" alt="image" src="https://github.com/EasyAndBeauty/DailyReceipt-Flutter/assets/82160479/a1776e85-0269-4087-a9e1-4d5c3c2635fe">

- 오늘 날짜가 회색 원으로 표시됩니다.
- 선택된 날짜(selectedDate)가 검정색으로 표시됩니다.
- todo가 있는 날은 초록색 indicator가 표시됩니다. (입력한 todo는 상태에 저장되지만 목록으로 나타나는 것은 아직 구현되지 않았습니다!)