### PR TITLE
[service]: 타이머 로직 구현

### DIFF
--- a/assets/icons/arrow_down.svg
+++ b/assets/icons/arrow_down.svg
@@ -1,0 +1,3 @@
+  <svg width="28" height="16" viewBox="0 0 28 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M2 2L14 14L26 2" stroke="#AAAAAA" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </svg>

--- a/lib/models/todo_timer.dart
+++ b/lib/models/todo_timer.dart
@@ -1,13 +1,13 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 
-// Define the states
 enum TimerState { idle, running, paused, completed }
 
-// Define the events
 enum TimerEvent { start, pause, complete, reset }
 
 class TodoTimer extends ChangeNotifier {
+  static const Duration _timerInterval = Duration(seconds: 1);
+
   Duration focusedTime = Duration.zero;
   TimerState _state = TimerState.idle;
   Timer? _timer;
@@ -16,6 +16,13 @@ class TodoTimer extends ChangeNotifier {
   TodoTimer();
 
   TimerState get state => _state;
+
+  void onEvent(TimerEvent event) {
+    _transitionState(event);
+    if (!_isDisposed) {
+      notifyListeners();
+    }
+  }
 
   void _transitionState(TimerEvent event) {
     if (_isDisposed) return;
@@ -48,46 +55,35 @@ class TodoTimer extends ChangeNotifier {
     }
   }
 
-  void onEvent(TimerEvent event) {
-    _transitionState(event);
+  void _startTimer() {
+    _state = TimerState.running;
+    _timer = Timer.periodic(_timerInterval, _updateTimer);
+  }
+
+  void _updateTimer(Timer timer) {
+    focusedTime += _timerInterval;
     if (!_isDisposed) {
       notifyListeners();
     }
   }
 
-  void _startTimer() {
-    _state = TimerState.running;
-    _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
-      focusedTime += const Duration(seconds: 1);
-      if (!_isDisposed) {
-        notifyListeners();
-      }
-    });
-    print('Timer started.');
-  }
-
   void _pauseTimer() {
     _state = TimerState.paused;
     _timer?.cancel();
-    print('Timer paused.');
   }
 
   void _completeTimer() {
     _state = TimerState.completed;
     _timer?.cancel();
-    print('Timer completed.');
   }
 
   void _resetTimer() {
     _state = TimerState.idle;
     focusedTime = Duration.zero;
     _timer?.cancel();
-    print('Timer reset.');
   }
 
-  Duration getFocusedTime() {
-    return focusedTime;
-  }
+  Duration getFocusedTime() => focusedTime;
 
   @override
   void dispose() {

--- a/lib/models/todo_timer.dart
+++ b/lib/models/todo_timer.dart
@@ -1,0 +1,108 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+
+// Define the states
+enum TimerState { idle, running, paused, completed }
+
+// Define the events
+enum TimerEvent { start, pause, complete, reset }
+
+class TodoTimer extends ChangeNotifier {
+  final String todoTitle;
+  Duration totalFocusedTime;
+  Duration currentFocusedTime;
+  TimerState _state;
+  Timer? _timer;
+  bool _isDisposed = false;
+
+  TodoTimer({
+    required this.todoTitle,
+    this.totalFocusedTime = Duration.zero,
+  })  : currentFocusedTime = Duration.zero,
+        _state = TimerState.idle;
+
+  TimerState get state => _state;
+
+  void _transitionState(TimerEvent event) {
+    if (_isDisposed) return;
+
+    switch (_state) {
+      case TimerState.idle:
+        if (event == TimerEvent.start) {
+          _startTimer();
+        }
+        break;
+      case TimerState.running:
+        if (event == TimerEvent.pause) {
+          _pauseTimer();
+        } else if (event == TimerEvent.complete) {
+          _completeTimer();
+        }
+        break;
+      case TimerState.paused:
+        if (event == TimerEvent.start) {
+          _startTimer();
+        } else if (event == TimerEvent.complete) {
+          _completeTimer();
+        }
+        break;
+      case TimerState.completed:
+        if (event == TimerEvent.reset) {
+          _resetTimer();
+        }
+        break;
+    }
+  }
+
+  void onEvent(TimerEvent event) {
+    _transitionState(event);
+    if (!_isDisposed) {
+      notifyListeners();
+    }
+  }
+
+  void _startTimer() {
+    _state = TimerState.running;
+    _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      currentFocusedTime += const Duration(seconds: 1);
+      if (!_isDisposed) {
+        notifyListeners();
+      }
+    });
+    print('Timer started.');
+  }
+
+  void _pauseTimer() {
+    _state = TimerState.paused;
+    _timer?.cancel();
+    print('Timer paused.');
+  }
+
+  void _completeTimer() {
+    _state = TimerState.completed;
+    _timer?.cancel();
+    totalFocusedTime += currentFocusedTime;
+    currentFocusedTime = Duration.zero;
+    print('Timer completed.');
+  }
+
+  void _resetTimer() {
+    _state = TimerState.idle;
+    totalFocusedTime = Duration.zero;
+    currentFocusedTime = Duration.zero;
+    _timer?.cancel();
+    print('Timer reset.');
+  }
+
+  Duration getTotalFocusedTime() {
+    return totalFocusedTime +
+        (state == TimerState.running ? currentFocusedTime : Duration.zero);
+  }
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    _timer?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/models/todo_timer.dart
+++ b/lib/models/todo_timer.dart
@@ -8,18 +8,12 @@ enum TimerState { idle, running, paused, completed }
 enum TimerEvent { start, pause, complete, reset }
 
 class TodoTimer extends ChangeNotifier {
-  final String todoTitle;
-  Duration totalFocusedTime;
-  Duration currentFocusedTime;
-  TimerState _state;
+  Duration focusedTime = Duration.zero;
+  TimerState _state = TimerState.idle;
   Timer? _timer;
   bool _isDisposed = false;
 
-  TodoTimer({
-    required this.todoTitle,
-    this.totalFocusedTime = Duration.zero,
-  })  : currentFocusedTime = Duration.zero,
-        _state = TimerState.idle;
+  TodoTimer();
 
   TimerState get state => _state;
 
@@ -64,7 +58,7 @@ class TodoTimer extends ChangeNotifier {
   void _startTimer() {
     _state = TimerState.running;
     _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
-      currentFocusedTime += const Duration(seconds: 1);
+      focusedTime += const Duration(seconds: 1);
       if (!_isDisposed) {
         notifyListeners();
       }
@@ -81,22 +75,18 @@ class TodoTimer extends ChangeNotifier {
   void _completeTimer() {
     _state = TimerState.completed;
     _timer?.cancel();
-    totalFocusedTime += currentFocusedTime;
-    currentFocusedTime = Duration.zero;
     print('Timer completed.');
   }
 
   void _resetTimer() {
     _state = TimerState.idle;
-    totalFocusedTime = Duration.zero;
-    currentFocusedTime = Duration.zero;
+    focusedTime = Duration.zero;
     _timer?.cancel();
     print('Timer reset.');
   }
 
-  Duration getTotalFocusedTime() {
-    return totalFocusedTime +
-        (state == TimerState.running ? currentFocusedTime : Duration.zero);
+  Duration getFocusedTime() {
+    return focusedTime;
   }
 
   @override

--- a/lib/models/todos.dart
+++ b/lib/models/todos.dart
@@ -35,6 +35,14 @@ class Todos extends ChangeNotifier {
     }
   }
 
+  void addAccumulatedTime(int id, Duration additionalTime) {
+    int index = _todos.indexWhere((todo) => todo.id == id);
+    if (index != -1) {
+      _todos[index].accumulatedTime += additionalTime;
+      notifyListeners();
+    }
+  }
+
   Map<DateTime, List<Todo>> groupTodosByDate(List<Todo> todos) {
     Map<DateTime, List<Todo>> grouped = {};
 
@@ -54,10 +62,10 @@ class Todo {
   final int id;
   String content;
   bool isDone;
-
   final DateTime createdAt;
   DateTime? completedAt;
   DateTime scheduledDate;
+  Duration accumulatedTime; // New field to track accumulated time
 
   Todo({
     required this.id,
@@ -66,5 +74,6 @@ class Todo {
     required this.createdAt,
     this.completedAt,
     required this.scheduledDate,
+    this.accumulatedTime = Duration.zero, // Initialize with zero duration
   });
 }

--- a/lib/screens/todos.dart
+++ b/lib/screens/todos.dart
@@ -56,6 +56,8 @@ class _TodosScreenState extends State<TodosScreen> {
       showModalBottomSheet(
         context: context,
         isScrollControlled: true,
+        isDismissible: false,
+        enableDrag: false,
         builder: (context) {
           return ChangeNotifierProvider(
             create: (_) => TodoTimer(),

--- a/lib/screens/todos.dart
+++ b/lib/screens/todos.dart
@@ -51,14 +51,22 @@ class _TodosScreenState extends State<TodosScreen> {
       editController.clear();
     }
 
-    void showTimerBottomSheet(BuildContext context, String todoTitle) {
+    // showTimerBottomSheet 함수 수정
+    void showTimerBottomSheet(BuildContext context, Todo todo) {
       showModalBottomSheet(
         context: context,
         isScrollControlled: true,
         builder: (context) {
           return ChangeNotifierProvider(
-            create: (_) => TodoTimer(todoTitle: todoTitle),
-            child: TimerBottomSheet(),
+            create: (_) => TodoTimer(),
+            child: TimerBottomSheet(
+              todo: todo,
+              onCompleted: (focusedTime) {
+                todosProvider.addAccumulatedTime(
+                    todo.id, focusedTime); // 누적 시간 추가
+                Navigator.of(context).pop();
+              },
+            ),
           );
         },
       );
@@ -300,7 +308,7 @@ class _TodosScreenState extends State<TodosScreen> {
                                 color: Theme.of(context).colorScheme.onPrimary,
                                 onPressed: () {
                                   showTimerBottomSheet(
-                                      context, todos[index].content);
+                                      context, todos[index]); // Todo 객체 전달
                                 },
                               ),
                             ],

--- a/lib/screens/todos.dart
+++ b/lib/screens/todos.dart
@@ -216,6 +216,7 @@ class _TodosScreenState extends State<TodosScreen> {
                           ),
                         ),
                         child: ListTile(
+                          contentPadding: EdgeInsets.zero,
                           leading: IconButton(
                             icon: Icon(
                               todos[index].isDone

--- a/lib/screens/todos.dart
+++ b/lib/screens/todos.dart
@@ -1,6 +1,8 @@
 import 'package:daily_receipt/models/calendar.dart';
 import 'package:daily_receipt/models/todos.dart';
+import 'package:daily_receipt/models/todo_timer.dart';
 import 'package:daily_receipt/widgets/calendar_dialog.dart';
+import 'package:daily_receipt/widgets/timer_bottom_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
@@ -47,6 +49,19 @@ class _TodosScreenState extends State<TodosScreen> {
         editingId = null;
       });
       editController.clear();
+    }
+
+    void showTimerBottomSheet(BuildContext context, String todoTitle) {
+      showModalBottomSheet(
+        context: context,
+        isScrollControlled: true,
+        builder: (context) {
+          return ChangeNotifierProvider(
+            create: (_) => TodoTimer(todoTitle: todoTitle),
+            child: TimerBottomSheet(),
+          );
+        },
+      );
     }
 
     return Scaffold(
@@ -219,22 +234,23 @@ class _TodosScreenState extends State<TodosScreen> {
                                       .colorScheme
                                       .onBackground,
                                   decoration: InputDecoration(
-                                      isDense: true,
-                                      enabledBorder: UnderlineInputBorder(
-                                        borderSide: BorderSide(
-                                          color: Theme.of(context)
-                                              .colorScheme
-                                              .tertiary,
-                                        ),
+                                    isDense: true,
+                                    enabledBorder: UnderlineInputBorder(
+                                      borderSide: BorderSide(
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .tertiary,
                                       ),
-                                      focusedBorder: UnderlineInputBorder(
-                                        borderSide: BorderSide(
-                                          color: Theme.of(context)
-                                              .colorScheme
-                                              .tertiary,
-                                        ),
+                                    ),
+                                    focusedBorder: UnderlineInputBorder(
+                                      borderSide: BorderSide(
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .tertiary,
                                       ),
-                                      contentPadding: EdgeInsets.all(0)),
+                                    ),
+                                    contentPadding: EdgeInsets.all(0),
+                                  ),
                                   onSubmitted: (_) => updateTodo(),
                                 )
                               : Text(
@@ -277,6 +293,14 @@ class _TodosScreenState extends State<TodosScreen> {
                                 color: Theme.of(context).colorScheme.error,
                                 onPressed: () {
                                   todosProvider.remove(todos[index].id);
+                                },
+                              ),
+                              IconButton(
+                                icon: const Icon(Icons.timer),
+                                color: Theme.of(context).colorScheme.onPrimary,
+                                onPressed: () {
+                                  showTimerBottomSheet(
+                                      context, todos[index].content);
                                 },
                               ),
                             ],

--- a/lib/widgets/buttons.dart
+++ b/lib/widgets/buttons.dart
@@ -78,6 +78,24 @@ class TextButtonCustom extends StatelessWidget {
   }
 }
 
+class CancelButton extends StatelessWidget {
+  const CancelButton({super.key, required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButtonCustom(
+      text: 'Cancel',
+      iconPath: null,
+      type: ButtonType.basic,
+      textColor: Theme.of(context).colorScheme.secondary,
+      isBold: false,
+      onPressed: onPressed,
+    );
+  }
+}
+
 class StopButton extends StatelessWidget {
   const StopButton({super.key, required this.onPressed});
 

--- a/lib/widgets/buttons.dart
+++ b/lib/widgets/buttons.dart
@@ -79,9 +79,11 @@ class TextButtonCustom extends StatelessWidget {
 }
 
 class CancelButton extends StatelessWidget {
-  const CancelButton({super.key, required this.onPressed});
-
   final VoidCallback onPressed;
+  final Color? color;
+
+  const CancelButton({Key? key, required this.onPressed, this.color})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -89,7 +91,7 @@ class CancelButton extends StatelessWidget {
       text: 'Cancel',
       iconPath: null,
       type: ButtonType.basic,
-      textColor: Theme.of(context).colorScheme.secondary,
+      textColor: color ?? Theme.of(context).colorScheme.secondary, // color 사용
       isBold: false,
       onPressed: onPressed,
     );
@@ -108,6 +110,24 @@ class StopButton extends StatelessWidget {
       iconPath: null,
       type: ButtonType.danger,
       textColor: Theme.of(context).colorScheme.error,
+      isBold: false,
+      onPressed: onPressed,
+    );
+  }
+}
+
+class PauseButton extends StatelessWidget {
+  const PauseButton({super.key, required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButtonCustom(
+      text: 'Pause',
+      iconPath: null,
+      type: ButtonType.basic,
+      textColor: Theme.of(context).colorScheme.secondary,
       isBold: false,
       onPressed: onPressed,
     );

--- a/lib/widgets/confirmation_dialog.dart
+++ b/lib/widgets/confirmation_dialog.dart
@@ -6,33 +6,44 @@ class ConfirmationDialog extends StatelessWidget {
   final VoidCallback onConfirm;
 
   const ConfirmationDialog({
+    Key? key,
     required this.title,
     required this.content,
     required this.onConfirm,
-  });
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     return AlertDialog(
-      backgroundColor: theme.colorScheme.surface,
-      title: Text(title, style: theme.textTheme.titleMedium),
-      content: Text(content, style: theme.textTheme.bodyMedium),
-      actions: <Widget>[
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      title: Align(
+        alignment: Alignment.centerLeft,
+        child: Text(
+          title,
+          style: Theme.of(context).textTheme.titleSmall,
+        ),
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            content,
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.bodyLarge,
+          ),
+        ],
+      ),
+      actions: [
         TextButton(
-          onPressed: () {
-            Navigator.of(context).pop(); // 모달만 닫기
-          },
-          child: Text('취소', style: theme.textTheme.bodySmall),
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text('취소'),
         ),
         TextButton(
           onPressed: () {
             onConfirm();
-            Navigator.of(context).pop(); // 모달 닫기
+            Navigator.of(context).pop();
           },
-          child: Text('확인',
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: theme.colorScheme.error)),
+          child: Text('확인'),
         ),
       ],
     );

--- a/lib/widgets/confirmation_dialog.dart
+++ b/lib/widgets/confirmation_dialog.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:daily_receipt/widgets/dashed_line_painter.dart';
+import 'package:daily_receipt/widgets/buttons.dart';
 
 class ConfirmationDialog extends StatelessWidget {
   final String title;
@@ -14,38 +16,60 @@ class ConfirmationDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return AlertDialog(
+    return Dialog(
       backgroundColor: Theme.of(context).colorScheme.surface,
-      title: Align(
-        alignment: Alignment.centerLeft,
-        child: Text(
-          title,
-          style: Theme.of(context).textTheme.titleSmall,
-        ),
-      ),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            content,
-            textAlign: TextAlign.center,
-            style: Theme.of(context).textTheme.bodyLarge,
+      child: SizedBox(
+        width: 400, // 고정 너비
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  title,
+                  style: Theme.of(context).textTheme.titleSmall,
+                ),
+              ),
+              const SizedBox(height: 16),
+              Column(
+                mainAxisSize: MainAxisSize.min,
+                mainAxisAlignment: MainAxisAlignment.center, // 세로 중앙 정렬
+                children: [
+                  Text(
+                    content,
+                    textAlign: TextAlign.center,
+                    style: Theme.of(context).textTheme.bodyLarge,
+                  ),
+                ],
+              ),
+              const SizedBox(height: 24),
+              CustomPaint(
+                size: const Size(double.infinity, 1),
+                painter: DashedLinePainter(
+                  color: Theme.of(context).colorScheme.onSurface,
+                ),
+              ),
+              const SizedBox(height: 16),
+              ButtonBar(
+                alignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  CancelButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
+                  StopButton(
+                    onPressed: () {
+                      onConfirm();
+                      Navigator.of(context).pop();
+                    },
+                  ),
+                ],
+              ),
+            ],
           ),
-        ],
+        ),
       ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(),
-          child: Text('취소'),
-        ),
-        TextButton(
-          onPressed: () {
-            onConfirm();
-            Navigator.of(context).pop();
-          },
-          child: Text('확인'),
-        ),
-      ],
     );
   }
 }

--- a/lib/widgets/confirmation_dialog.dart
+++ b/lib/widgets/confirmation_dialog.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+class ConfirmationDialog extends StatelessWidget {
+  final String title;
+  final String content;
+  final VoidCallback onConfirm;
+
+  const ConfirmationDialog({
+    required this.title,
+    required this.content,
+    required this.onConfirm,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return AlertDialog(
+      title: Text(title, style: theme.textTheme.titleMedium),
+      content: Text(content, style: theme.textTheme.bodyMedium),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () {
+            Navigator.of(context).pop(); // 모달만 닫기
+          },
+          child: Text('취소', style: theme.textTheme.bodySmall),
+        ),
+        TextButton(
+          onPressed: () {
+            onConfirm();
+            Navigator.of(context).pop(); // 모달 닫기
+          },
+          child: Text('확인',
+              style: theme.textTheme.bodySmall
+                  ?.copyWith(color: theme.colorScheme.error)),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/confirmation_dialog.dart
+++ b/lib/widgets/confirmation_dialog.dart
@@ -3,6 +3,11 @@ import 'package:daily_receipt/widgets/dashed_line_painter.dart';
 import 'package:daily_receipt/widgets/buttons.dart';
 
 class ConfirmationDialog extends StatelessWidget {
+  static const double _dialogWidth = 400;
+  static const double _dialogPadding = 24.0;
+  static const double _contentSpacing = 16.0;
+  static const double _dashedLineHeight = 1;
+
   final String title;
   final String content;
   final VoidCallback onConfirm;
@@ -16,60 +21,72 @@ class ConfirmationDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return Dialog(
-      backgroundColor: Theme.of(context).colorScheme.surface,
-      child: SizedBox(
-        width: 400, // 고정 너비
+      backgroundColor: theme.colorScheme.surface,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: _dialogWidth),
         child: Padding(
-          padding: const EdgeInsets.all(24.0),
+          padding: const EdgeInsets.all(_dialogPadding),
           child: Column(
             mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              Align(
-                alignment: Alignment.centerLeft,
-                child: Text(
-                  title,
-                  style: Theme.of(context).textTheme.titleSmall,
-                ),
-              ),
-              const SizedBox(height: 16),
-              Column(
-                mainAxisSize: MainAxisSize.min,
-                mainAxisAlignment: MainAxisAlignment.center, // 세로 중앙 정렬
-                children: [
-                  Text(
-                    content,
-                    textAlign: TextAlign.center,
-                    style: Theme.of(context).textTheme.bodyLarge,
-                  ),
-                ],
-              ),
-              const SizedBox(height: 24),
-              CustomPaint(
-                size: const Size(double.infinity, 1),
-                painter: DashedLinePainter(
-                  color: Theme.of(context).colorScheme.onSurface,
-                ),
-              ),
-              const SizedBox(height: 16),
-              ButtonBar(
-                alignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  CancelButton(
-                    onPressed: () => Navigator.of(context).pop(),
-                  ),
-                  StopButton(
-                    onPressed: () {
-                      onConfirm();
-                      Navigator.of(context).pop();
-                    },
-                  ),
-                ],
-              ),
+              _buildTitle(theme),
+              const SizedBox(height: _contentSpacing),
+              _buildContent(theme),
+              const SizedBox(height: _contentSpacing),
+              _buildDashedLine(theme),
+              const SizedBox(height: _contentSpacing),
+              _buildActionButtons(context),
             ],
           ),
         ),
       ),
+    );
+  }
+
+  Widget _buildTitle(ThemeData theme) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Text(
+        title,
+        style: theme.textTheme.titleSmall,
+      ),
+    );
+  }
+
+  Widget _buildContent(ThemeData theme) {
+    return Text(
+      content,
+      textAlign: TextAlign.center,
+      style: theme.textTheme.bodyLarge,
+    );
+  }
+
+  Widget _buildDashedLine(ThemeData theme) {
+    return CustomPaint(
+      size: const Size(double.infinity, _dashedLineHeight),
+      painter: DashedLinePainter(
+        color: theme.colorScheme.onSurface,
+      ),
+    );
+  }
+
+  Widget _buildActionButtons(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        CancelButton(
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        StopButton(
+          onPressed: () {
+            onConfirm();
+            Navigator.of(context).pop();
+          },
+        ),
+      ],
     );
   }
 }

--- a/lib/widgets/confirmation_dialog.dart
+++ b/lib/widgets/confirmation_dialog.dart
@@ -15,6 +15,7 @@ class ConfirmationDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return AlertDialog(
+      backgroundColor: theme.colorScheme.surface,
       title: Text(title, style: theme.textTheme.titleMedium),
       content: Text(content, style: theme.textTheme.bodyMedium),
       actions: <Widget>[

--- a/lib/widgets/dashed_line_painter.dart
+++ b/lib/widgets/dashed_line_painter.dart
@@ -1,0 +1,32 @@
+// dashed_line_painter.dart
+import 'package:flutter/material.dart';
+
+class DashedLinePainter extends CustomPainter {
+  final Color color;
+
+  DashedLinePainter({required this.color});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    const dashWidth = 5.0;
+    const dashSpace = 3.0;
+    final paint = Paint()
+      ..color = color
+      ..strokeWidth = 1.0;
+
+    double startX = 0;
+    while (startX < size.width) {
+      canvas.drawLine(
+        Offset(startX, 0),
+        Offset(startX + dashWidth, 0),
+        paint,
+      );
+      startX += dashWidth + dashSpace;
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) {
+    return false;
+  }
+}

--- a/lib/widgets/timer_bottom_sheet.dart
+++ b/lib/widgets/timer_bottom_sheet.dart
@@ -4,6 +4,7 @@ import 'package:daily_receipt/models/todo_timer.dart';
 import 'package:daily_receipt/widgets/confirmation_dialog.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:daily_receipt/widgets/buttons.dart';
+import 'package:daily_receipt/widgets/dashed_line_painter.dart';
 
 class TimerBottomSheet extends StatelessWidget {
   @override
@@ -198,35 +199,5 @@ class TimerBottomSheet extends StatelessWidget {
         );
       },
     );
-  }
-}
-
-class DashedLinePainter extends CustomPainter {
-  final Color color;
-
-  DashedLinePainter({required this.color});
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    const dashWidth = 5.0;
-    const dashSpace = 3.0;
-    final paint = Paint()
-      ..color = color
-      ..strokeWidth = 1.0;
-
-    double startX = 0;
-    while (startX < size.width) {
-      canvas.drawLine(
-        Offset(startX, 0),
-        Offset(startX + dashWidth, 0),
-        paint,
-      );
-      startX += dashWidth + dashSpace;
-    }
-  }
-
-  @override
-  bool shouldRepaint(covariant CustomPainter oldDelegate) {
-    return false;
   }
 }

--- a/lib/widgets/timer_bottom_sheet.dart
+++ b/lib/widgets/timer_bottom_sheet.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:daily_receipt/models/todo_timer.dart';
 import 'package:daily_receipt/widgets/confirmation_dialog.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:daily_receipt/widgets/buttons.dart';
 
 class TimerBottomSheet extends StatelessWidget {
   @override
@@ -46,6 +47,7 @@ class TimerBottomSheet extends StatelessWidget {
     return Container(
       width: MediaQuery.of(context).size.width,
       height: MediaQuery.of(context).size.height * 0.95,
+      padding: const EdgeInsets.symmetric(horizontal: 16),
       decoration: BoxDecoration(
         color: theme.colorScheme.primary,
         border: Border(
@@ -65,7 +67,7 @@ class TimerBottomSheet extends StatelessWidget {
             GestureDetector(
               onTap: () => Navigator.of(context).pop(),
               child: Padding(
-                padding: const EdgeInsets.symmetric(vertical: 16.0),
+                padding: const EdgeInsets.symmetric(vertical: 32.0),
                 child: SvgPicture.string(
                   '''
                   <svg width="28" height="16" viewBox="0 0 28 16" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -79,82 +81,91 @@ class TimerBottomSheet extends StatelessWidget {
             ),
             Expanded(
               child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  Text(
-                    'TODO : ${todoTimer.todoTitle}',
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      fontWeight: FontWeight.w700,
-                      height: 18 / 14,
-                      letterSpacing: -0.005 * 14,
-                      color: theme.colorScheme.onPrimary,
-                    ),
-                    textAlign: TextAlign.center,
-                  ),
-                  const SizedBox(height: 8),
-                  todoTimer.state == TimerState.idle
-                      ? Text(
-                          '집중한 시간 : ${todoTimer.totalFocusedTime.inMinutes}분',
+                  const Spacer(flex: 1), // 부모의 높이의 1/4만큼의 공간을 차지
+                  Flexible(
+                    flex: 3,
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        Text(
+                          'TODO : ${todoTimer.todoTitle}',
                           style: theme.textTheme.bodySmall?.copyWith(
                             fontWeight: FontWeight.w700,
                             height: 18 / 14,
                             letterSpacing: -0.005 * 14,
-                            color:
-                                _getColorByTimerState(todoTimer.state, false),
+                            color: theme.colorScheme.onPrimary,
                           ),
                           textAlign: TextAlign.center,
-                        )
-                      : const SizedBox(),
-                  const SizedBox(height: 32),
-                  Text(
-                    '${(todoTimer.currentFocusedTime.inMinutes % 60).toString().padLeft(2, '0')}:${(todoTimer.currentFocusedTime.inSeconds % 60).toString().padLeft(2, '0')}',
-                    style: theme.textTheme.headlineLarge?.copyWith(
-                      fontFamily: 'Courier Prime',
-                      fontSize: 92,
-                      fontWeight: FontWeight.w400,
-                      height: 103 / 92,
-                      letterSpacing: -0.005 * 92,
-                      color: _getColorByTimerState(todoTimer.state, true),
+                        ),
+                        const SizedBox(height: 8),
+                        todoTimer.state == TimerState.idle
+                            ? Text(
+                                '집중한 시간 : ${todoTimer.totalFocusedTime.inMinutes}분',
+                                style: theme.textTheme.bodySmall?.copyWith(
+                                  fontWeight: FontWeight.w700,
+                                  height: 18 / 14,
+                                  letterSpacing: -0.005 * 14,
+                                  color: _getColorByTimerState(
+                                      todoTimer.state, false),
+                                ),
+                                textAlign: TextAlign.center,
+                              )
+                            : const SizedBox(),
+                        const SizedBox(height: 32),
+                        Text(
+                          '${(todoTimer.currentFocusedTime.inMinutes % 60).toString().padLeft(2, '0')}:${(todoTimer.currentFocusedTime.inSeconds % 60).toString().padLeft(2, '0')}',
+                          style: theme.textTheme.headlineLarge?.copyWith(
+                            fontFamily: 'Courier Prime',
+                            fontSize: 92,
+                            fontWeight: FontWeight.w400,
+                            height: 103 / 92,
+                            letterSpacing: -0.005 * 92,
+                            color: _getColorByTimerState(todoTimer.state, true),
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                        const SizedBox(height: 16),
+                        SizedBox(
+                          width: 184,
+                          child: Text(
+                            _getMessageByTimerState(todoTimer.state),
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              fontWeight: FontWeight.w700,
+                              height: 20 / 16,
+                              letterSpacing: -0.005 * 16,
+                              color:
+                                  _getColorByTimerState(todoTimer.state, false),
+                            ),
+                            textAlign: TextAlign.center,
+                          ),
+                        ),
+                      ],
                     ),
-                    textAlign: TextAlign.center,
                   ),
-                  const SizedBox(height: 16),
-                  SizedBox(
-                    width: 184,
-                    child: Text(
-                      _getMessageByTimerState(todoTimer.state),
-                      style: theme.textTheme.bodyMedium?.copyWith(
-                        fontWeight: FontWeight.w700,
-                        height: 20 / 16,
-                        letterSpacing: -0.005 * 16,
-                        color: _getColorByTimerState(todoTimer.state, false),
-                      ),
-                      textAlign: TextAlign.center,
-                    ),
-                  ),
+                  const Spacer(flex: 1), // 나머지 공간 채우기
                 ],
               ),
+            ),
+            CustomPaint(
+              size: const Size(double.infinity, 1),
+              painter: DashedLinePainter(color: theme.colorScheme.onPrimary),
             ),
             Padding(
               padding: const EdgeInsets.all(16.0),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  TextButton(
+                  StopButton(
                     onPressed: () {
                       if (todoTimer.state == TimerState.running ||
                           todoTimer.state == TimerState.paused) {
                         _showStopConfirmationDialog(context, todoTimer);
                       }
                     },
-                    child: Text(
-                      'Stop',
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: theme.colorScheme.error,
-                      ),
-                    ),
                   ),
-                  TextButton(
+                  PlayButton(
                     onPressed: () {
                       if (todoTimer.state == TimerState.idle ||
                           todoTimer.state == TimerState.paused) {
@@ -163,12 +174,6 @@ class TimerBottomSheet extends StatelessWidget {
                         todoTimer.onEvent(TimerEvent.pause);
                       }
                     },
-                    child: Text(
-                      todoTimer.state == TimerState.running ? 'Pause' : 'Start',
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: theme.colorScheme.onPrimary,
-                      ),
-                    ),
                   ),
                 ],
               ),
@@ -193,5 +198,35 @@ class TimerBottomSheet extends StatelessWidget {
         );
       },
     );
+  }
+}
+
+class DashedLinePainter extends CustomPainter {
+  final Color color;
+
+  DashedLinePainter({required this.color});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    const dashWidth = 5.0;
+    const dashSpace = 3.0;
+    final paint = Paint()
+      ..color = color
+      ..strokeWidth = 1.0;
+
+    double startX = 0;
+    while (startX < size.width) {
+      canvas.drawLine(
+        Offset(startX, 0),
+        Offset(startX + dashWidth, 0),
+        paint,
+      );
+      startX += dashWidth + dashSpace;
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) {
+    return false;
   }
 }

--- a/lib/widgets/timer_bottom_sheet.dart
+++ b/lib/widgets/timer_bottom_sheet.dart
@@ -75,7 +75,7 @@ class TimerBottomSheet extends StatelessWidget {
 
   void _showStopConfirmationDialog(BuildContext context, TodoTimer todoTimer) {
     showDialog(
-      context: context,
+      context: Navigator.of(context, rootNavigator: true).context,
       builder: (BuildContext context) {
         return ConfirmationDialog(
           title: '타이머 중지',

--- a/lib/widgets/timer_bottom_sheet.dart
+++ b/lib/widgets/timer_bottom_sheet.dart
@@ -32,33 +32,36 @@ class TimerBottomSheet extends StatelessWidget {
     final todoTimer = Provider.of<TodoTimer>(context);
     final theme = Theme.of(context);
 
-    return Container(
-      width: MediaQuery.of(context).size.width,
-      height: MediaQuery.of(context).size.height * _bottomSheetHeight,
-      padding: const EdgeInsets.symmetric(horizontal: _horizontalPadding),
-      decoration: _buildBottomSheetDecoration(theme),
-      child: SafeArea(
-        child: Column(
-          children: [
-            _buildCloseButton(context),
-            Expanded(
-              child: Column(
-                children: [
-                  const Spacer(flex: 1),
-                  Flexible(
-                    flex: 3,
-                    child: _buildTimerContent(context, todoTimer, theme),
-                  ),
-                  const Spacer(flex: 1),
-                ],
+    return PopScope(
+      child: Container(
+        width: MediaQuery.of(context).size.width,
+        height: MediaQuery.of(context).size.height * _bottomSheetHeight,
+        padding: const EdgeInsets.symmetric(horizontal: _horizontalPadding),
+        decoration: _buildBottomSheetDecoration(theme),
+        child: SafeArea(
+          child: Column(
+            children: [
+              _buildCloseButton(context, todoTimer),
+              Expanded(
+                child: Column(
+                  children: [
+                    const Spacer(flex: 1),
+                    Flexible(
+                      flex: 3,
+                      child: _buildTimerContent(context, todoTimer, theme),
+                    ),
+                    const Spacer(flex: 1),
+                  ],
+                ),
               ),
-            ),
-            _buildDashedLine(theme),
-            Padding(
-              padding: const EdgeInsets.all(_horizontalPadding),
-              child: _buildControlButtons(todoTimer.state, context, todoTimer),
-            ),
-          ],
+              _buildDashedLine(theme),
+              Padding(
+                padding: const EdgeInsets.all(_horizontalPadding),
+                child:
+                    _buildControlButtons(todoTimer.state, context, todoTimer),
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -80,9 +83,9 @@ class TimerBottomSheet extends StatelessWidget {
     );
   }
 
-  Widget _buildCloseButton(BuildContext context) {
+  Widget _buildCloseButton(BuildContext context, TodoTimer todoTimer) {
     return GestureDetector(
-      onTap: () => Navigator.of(context).pop(),
+      onTap: () => _handleCloseButtonTap(context, todoTimer),
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: _verticalPadding),
         child: SvgPicture.asset(
@@ -92,6 +95,14 @@ class TimerBottomSheet extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  void _handleCloseButtonTap(BuildContext context, TodoTimer todoTimer) {
+    if (todoTimer.state == TimerState.idle) {
+      Navigator.of(context).pop();
+    } else {
+      _showStopConfirmationDialog(context, todoTimer);
+    }
   }
 
   Widget _buildTimerContent(

--- a/lib/widgets/timer_bottom_sheet.dart
+++ b/lib/widgets/timer_bottom_sheet.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:daily_receipt/models/todo_timer.dart';
+import 'package:daily_receipt/widgets/confirmation_dialog.dart';
+
+class TimerBottomSheet extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final todoTimer = Provider.of<TodoTimer>(context);
+    final theme = Theme.of(context);
+
+    return Container(
+      height: MediaQuery.of(context).size.height * 0.9,
+      color: theme.colorScheme.primary,
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            'TODO: ${todoTimer.todoTitle}',
+            style: theme.textTheme.bodyLarge
+                ?.copyWith(color: theme.colorScheme.onPrimary),
+          ),
+          const SizedBox(height: 20),
+          Text(
+            '집중 시간: ${(todoTimer.currentFocusedTime.inMinutes % 60).toString().padLeft(2, '0')}:${(todoTimer.currentFocusedTime.inSeconds % 60).toString().padLeft(2, '0')}',
+            style: theme.textTheme.bodyMedium
+                ?.copyWith(color: theme.colorScheme.onPrimary),
+          ),
+          const SizedBox(height: 10),
+          Text(
+            '조금 더 집중한 이 시간이\n더 빛나는 내일을 만들어 줄 거예요.',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodyMedium
+                ?.copyWith(color: theme.colorScheme.onPrimary),
+          ),
+          const SizedBox(height: 30),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              TextButton(
+                onPressed: () {
+                  if (todoTimer.state == TimerState.running ||
+                      todoTimer.state == TimerState.paused) {
+                    _showStopConfirmationDialog(context, todoTimer);
+                  }
+                },
+                child: Text(
+                  'Stop',
+                  style: theme.textTheme.bodySmall
+                      ?.copyWith(color: theme.colorScheme.error),
+                ),
+              ),
+              TextButton(
+                onPressed: () {
+                  if (todoTimer.state == TimerState.idle ||
+                      todoTimer.state == TimerState.paused) {
+                    todoTimer.onEvent(TimerEvent.start);
+                  } else if (todoTimer.state == TimerState.running) {
+                    todoTimer.onEvent(TimerEvent.pause);
+                  }
+                },
+                child: Text(
+                  todoTimer.state == TimerState.running ? 'Pause' : 'Start',
+                  style: theme.textTheme.bodySmall
+                      ?.copyWith(color: theme.colorScheme.onPrimary),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showStopConfirmationDialog(BuildContext context, TodoTimer todoTimer) {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return ConfirmationDialog(
+          title: '타이머 중지',
+          content: '정말로 타이머를 중지하시겠습니까?',
+          onConfirm: () {
+            todoTimer.onEvent(TimerEvent.complete);
+            Navigator.of(context).pop(); // 바텀시트 닫기
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/widgets/timer_bottom_sheet.dart
+++ b/lib/widgets/timer_bottom_sheet.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:daily_receipt/models/todo_timer.dart';
 import 'package:daily_receipt/widgets/confirmation_dialog.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 
 class TimerBottomSheet extends StatelessWidget {
   @override
@@ -9,66 +10,171 @@ class TimerBottomSheet extends StatelessWidget {
     final todoTimer = Provider.of<TodoTimer>(context);
     final theme = Theme.of(context);
 
+    String _getMessageByTimerState(TimerState state) {
+      switch (state) {
+        case TimerState.idle:
+          return 'Play 버튼을 눌러 타이머를 시작해보세요.';
+        case TimerState.running:
+          return '조금 더 집중한 이 시간이\n더 빛나는 내일을 만들어 줄 거예요.';
+        case TimerState.paused:
+          return '다시 집중하고 싶다면\nStart 버튼을 눌러주세요.';
+        case TimerState.completed:
+          return '훌륭해요! 오늘의 집중이\n내일의 성과로 이어질 거예요.';
+      }
+    }
+
+    Color _getColorByTimerState(TimerState state, bool isReversed) {
+      Color activeColor = isReversed
+          ? theme.colorScheme.onPrimary
+          : theme.colorScheme.secondary;
+      Color inactiveColor = isReversed
+          ? theme.colorScheme.secondary
+          : theme.colorScheme.onPrimary;
+
+      switch (state) {
+        case TimerState.idle:
+          return inactiveColor;
+        case TimerState.running:
+          return activeColor;
+        case TimerState.paused:
+          return inactiveColor;
+        case TimerState.completed:
+          return activeColor;
+      }
+    }
+
     return Container(
-      height: MediaQuery.of(context).size.height * 0.9,
-      color: theme.colorScheme.primary,
-      padding: const EdgeInsets.all(16.0),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Text(
-            'TODO: ${todoTimer.todoTitle}',
-            style: theme.textTheme.bodyLarge
-                ?.copyWith(color: theme.colorScheme.onPrimary),
+      width: MediaQuery.of(context).size.width,
+      height: MediaQuery.of(context).size.height * 0.95,
+      decoration: BoxDecoration(
+        color: theme.colorScheme.primary,
+        border: Border(
+          top: BorderSide(
+            color: theme.colorScheme.secondary,
+            width: 1,
           ),
-          const SizedBox(height: 20),
-          Text(
-            '집중 시간: ${(todoTimer.currentFocusedTime.inMinutes % 60).toString().padLeft(2, '0')}:${(todoTimer.currentFocusedTime.inSeconds % 60).toString().padLeft(2, '0')}',
-            style: theme.textTheme.bodyMedium
-                ?.copyWith(color: theme.colorScheme.onPrimary),
-          ),
-          const SizedBox(height: 10),
-          Text(
-            '조금 더 집중한 이 시간이\n더 빛나는 내일을 만들어 줄 거예요.',
-            textAlign: TextAlign.center,
-            style: theme.textTheme.bodyMedium
-                ?.copyWith(color: theme.colorScheme.onPrimary),
-          ),
-          const SizedBox(height: 30),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              TextButton(
-                onPressed: () {
-                  if (todoTimer.state == TimerState.running ||
-                      todoTimer.state == TimerState.paused) {
-                    _showStopConfirmationDialog(context, todoTimer);
-                  }
-                },
-                child: Text(
-                  'Stop',
-                  style: theme.textTheme.bodySmall
-                      ?.copyWith(color: theme.colorScheme.error),
+        ),
+        borderRadius: const BorderRadius.only(
+          topLeft: Radius.circular(30),
+          topRight: Radius.circular(30),
+        ),
+      ),
+      child: SafeArea(
+        child: Column(
+          children: [
+            GestureDetector(
+              onTap: () => Navigator.of(context).pop(),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 16.0),
+                child: SvgPicture.string(
+                  '''
+                  <svg width="28" height="16" viewBox="0 0 28 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M2 2L14 14L26 2" stroke="#AAAAAA" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                  ''',
+                  width: 28,
+                  height: 16,
                 ),
               ),
-              TextButton(
-                onPressed: () {
-                  if (todoTimer.state == TimerState.idle ||
-                      todoTimer.state == TimerState.paused) {
-                    todoTimer.onEvent(TimerEvent.start);
-                  } else if (todoTimer.state == TimerState.running) {
-                    todoTimer.onEvent(TimerEvent.pause);
-                  }
-                },
-                child: Text(
-                  todoTimer.state == TimerState.running ? 'Pause' : 'Start',
-                  style: theme.textTheme.bodySmall
-                      ?.copyWith(color: theme.colorScheme.onPrimary),
-                ),
+            ),
+            Expanded(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    'TODO : ${todoTimer.todoTitle}',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      fontWeight: FontWeight.w700,
+                      height: 18 / 14,
+                      letterSpacing: -0.005 * 14,
+                      color: theme.colorScheme.onPrimary,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 8),
+                  todoTimer.state == TimerState.idle
+                      ? Text(
+                          '집중한 시간 : ${todoTimer.totalFocusedTime.inMinutes}분',
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            fontWeight: FontWeight.w700,
+                            height: 18 / 14,
+                            letterSpacing: -0.005 * 14,
+                            color:
+                                _getColorByTimerState(todoTimer.state, false),
+                          ),
+                          textAlign: TextAlign.center,
+                        )
+                      : const SizedBox(),
+                  const SizedBox(height: 32),
+                  Text(
+                    '${(todoTimer.currentFocusedTime.inMinutes % 60).toString().padLeft(2, '0')}:${(todoTimer.currentFocusedTime.inSeconds % 60).toString().padLeft(2, '0')}',
+                    style: theme.textTheme.headlineLarge?.copyWith(
+                      fontFamily: 'Courier Prime',
+                      fontSize: 92,
+                      fontWeight: FontWeight.w400,
+                      height: 103 / 92,
+                      letterSpacing: -0.005 * 92,
+                      color: _getColorByTimerState(todoTimer.state, true),
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 16),
+                  SizedBox(
+                    width: 184,
+                    child: Text(
+                      _getMessageByTimerState(todoTimer.state),
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
+                        height: 20 / 16,
+                        letterSpacing: -0.005 * 16,
+                        color: _getColorByTimerState(todoTimer.state, false),
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                ],
               ),
-            ],
-          ),
-        ],
+            ),
+            Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  TextButton(
+                    onPressed: () {
+                      if (todoTimer.state == TimerState.running ||
+                          todoTimer.state == TimerState.paused) {
+                        _showStopConfirmationDialog(context, todoTimer);
+                      }
+                    },
+                    child: Text(
+                      'Stop',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.error,
+                      ),
+                    ),
+                  ),
+                  TextButton(
+                    onPressed: () {
+                      if (todoTimer.state == TimerState.idle ||
+                          todoTimer.state == TimerState.paused) {
+                        todoTimer.onEvent(TimerEvent.start);
+                      } else if (todoTimer.state == TimerState.running) {
+                        todoTimer.onEvent(TimerEvent.pause);
+                      }
+                    },
+                    child: Text(
+                      todoTimer.state == TimerState.running ? 'Pause' : 'Start',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onPrimary,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -78,11 +184,11 @@ class TimerBottomSheet extends StatelessWidget {
       context: Navigator.of(context, rootNavigator: true).context,
       builder: (BuildContext context) {
         return ConfirmationDialog(
-          title: '타이머 중지',
-          content: '정말로 타이머를 중지하시겠습니까?',
+          title: 'TODO: ${todoTimer.todoTitle}',
+          content: '타이머를 중지할까요?',
           onConfirm: () {
             todoTimer.onEvent(TimerEvent.complete);
-            Navigator.of(context).pop(); // 바텀시트 닫기
+            Navigator.of(context).pop();
           },
         );
       },

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -77,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "2fb815080e44a09b85e0f2ca8a820b15053982b2e714b59267719e8a9ff17097"
+      sha256: "576aaab8b1abdd452e0f656c3e73da9ead9d7880e15bdc494189d9c1a1baf0db"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.3"
+    version: "1.9.0"
   crypto:
     dependency: transitive
     description:
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: file
-      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -139,6 +139,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  flutter_svg:
+    dependency: "direct main"
+    description:
+      name: flutter_svg
+      sha256: "6ff9fa12892ae074092de2fa6a9938fb21dbabfdaa2ff57dc697ff912fc8d4b2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.6"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -226,6 +234,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.7"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.4"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -246,26 +278,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -302,10 +334,26 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
+  path_drawing:
+    dependency: transitive
+    description:
+      name: path_drawing
+      sha256: bbb1934c0cbb03091af082a6389ca2080345291ef07a5fa6d6e078ba8682f977
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      sha256: e3e67b1629e6f7e8100b367d3db6ba6af4b1f0bb80f64db18ef1fbabd2fa9ccf
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   path_provider:
     dependency: transitive
     description:
@@ -354,14 +402,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.1"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.2"
   platform:
     dependency: transitive
     description:
       name: platform
-      sha256: ae68c7bfcd7383af3629daafb32fb4e8681c7154428da4febcff06200585f102
+      sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.4"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -382,10 +438,10 @@ packages:
     dependency: transitive
     description:
       name: process
-      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
+      sha256: "21e54fd2faf1b5bdd5102afd25012184a6793927648ea81eea80552ac9405b32"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.4"
+    version: "5.0.2"
   provider:
     dependency: "direct main"
     description:
@@ -523,26 +579,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: a1f7595805820fcc05e5c52e3a231aedd0b72972cb333e8c738a8b1239448b6f
+      sha256: "7ee446762c2c50b3bd4ea96fe13ffac69919352bd3b4b17bac3f3465edc58073"
       url: "https://pub.dev"
     source: hosted
-    version: "1.24.9"
+    version: "1.25.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: a757b14fc47507060a162cc2530d9a4a2f92f5100a952c7443b5cad5ef5b106a
+      sha256: "2bc4b4ecddd75309300d8096f781c0e3280ca1ef85beda558d33fcbedc2eead4"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.9"
+    version: "0.6.0"
   typed_data:
     dependency: transitive
     description:
@@ -563,10 +619,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: c538be99af830f478718b51630ec1b6bee5e74e52c8a802d328d9e71d35d2583
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "11.10.0"
+    version: "14.2.1"
   watcher:
     dependency: transitive
     description:
@@ -575,14 +631,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.0"
   web_socket_channel:
     dependency: transitive
     description:
@@ -595,10 +643,10 @@ packages:
     dependency: transitive
     description:
       name: webdriver
-      sha256: "3c923e918918feeb90c4c9fdf1fe39220fa4c0e8e2c0fffaded174498ef86c49"
+      sha256: "003d7da9519e1e5f329422b36c4dcdf18d7d2978d1ba099ea4e45ba490ed845e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   webkit_inspection_protocol:
     dependency: transitive
     description:
@@ -623,6 +671,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.0"
   yaml:
     dependency: transitive
     description:
@@ -632,5 +688,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.2.0-194.0.dev <4.0.0"
-  flutter: ">=3.10.0"
+  dart: ">=3.4.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
#31 
#34 
#35 

## 어떻게 해결했나요?
1. `PopScope` 위젯을 사용하여 시스템 백 버튼 및 제스처에 대한 동작을 제어했습니다.
2. 타이머의 로직을 FSM형식으로 (idle, running, paused, completed)로 제어하게 했습니다.
3. 타이머 상태에 따라 BottomSheet 닫기 동작을 다르게 처리하도록 로직을 구현했습니다.
4. 타이머가 실행 중일 때 BottomSheet를 닫으려고 하면 확인 다이얼로그를 표시하도록 했습니다.
5. 타이머를 닫고 나면, todo의 누적 time에 추가되도록 했습니다.

주요 변경 사항:
- `TimerBottomSheet` 클래스의 `build` 메서드에 `PopScope`와 `GestureDetector`를 추가했습니다.
- `_handleCloseAttempt` 메서드를 새로 추가하여 닫기 시도를 처리합니다.
- `_showStopConfirmationDialog` 메서드를 수정하여 타이머 완료 후 BottomSheet를 안전하게 닫도록 했습니다.

코드 위치: `lib/widgets/timer_bottom_sheet.dart`

### 미리 보기
<img width="302" alt="image" src="https://github.com/user-attachments/assets/9a6a3aef-9504-4152-b516-45b2e37124cc">
<img width="323" alt="image" src="https://github.com/user-attachments/assets/308aaff8-9cad-4c69-91be-143b98943378">
<img width="328" alt="image" src="https://github.com/user-attachments/assets/58c690fa-75a3-4580-bfb2-7b7925ac9a3d">
<img width="323" alt="image" src="https://github.com/user-attachments/assets/a81cd059-27e5-474b-8c25-b16b7c9cf1db">

