### PR TITLE
[fix] 투두 이름이 길면 영수증에서 레이아웃이 깨지는 문제 해결

### DIFF
--- a/lib/widgets/receipt_item.dart
+++ b/lib/widgets/receipt_item.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+
 import 'receipt_text.dart';
 
 class ReceiptItem extends StatelessWidget {
@@ -12,7 +13,9 @@ class ReceiptItem extends StatelessWidget {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        ReceiptText(name),
+        Expanded(
+          child: ReceiptText(name),
+        ),
         ReceiptText(value),
       ],
     );

--- a/lib/widgets/receipt_text.dart
+++ b/lib/widgets/receipt_text.dart
@@ -12,6 +12,8 @@ class ReceiptText extends StatelessWidget {
       style: Theme.of(context).textTheme.titleSmall?.copyWith(
             color: Theme.of(context).colorScheme.primary,
           ),
+      overflow: TextOverflow.ellipsis,
+      maxLines: 1,
     );
   }
 }


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?

![스크린샷 2024-10-19 232327](https://github.com/user-attachments/assets/1ac313b1-2416-4660-bf04-968fb99ee831)


## 어떻게 해결했나요?

- 투두 이름에 Expanded 적용
- 한줄 넘어가면 말줄임표 처리

### 미리 보기

![스크린샷 2024-10-19 233459](https://github.com/user-attachments/assets/eaad76b9-5a77-4f06-921c-63e2a47f2055)
