### PR TITLE
[BUG/113] todo 모델 수정 및 svg import 유효화

### DIFF
--- a/lib/widgets/image_button.dart
+++ b/lib/widgets/image_button.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-// TODO: flutter_svg 패키지가 필요하므로, pubspec.yaml 파일에 다음을 추가하세요.
 import 'package:flutter_svg/flutter_svg.dart';
 
 class IconTextButton extends StatelessWidget {

--- a/lib/widgets/image_button.dart
+++ b/lib/widgets/image_button.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 // TODO: flutter_svg 패키지가 필요하므로, pubspec.yaml 파일에 다음을 추가하세요.
-// import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 
 class IconTextButton extends StatelessWidget {
   final String text;

--- a/test/models/todos_test.dart
+++ b/test/models/todos_test.dart
@@ -7,7 +7,7 @@ void main() {
 
     test('새로운 todo가 todos에 추가되어야 합니다.', () {
       var newTodo = Todo(
-        id: todosProvider.todos.length,
+        id: '1',
         content: 'test',
         createdAt: DateTime.now().toUtc(),
         scheduledDate: DateTime(2024, 1, 1),
@@ -23,7 +23,7 @@ void main() {
       final notExistsDate = DateTime(2024, 1, 2);
       var todos = [
         Todo(
-          id: 1,
+          id: '1',
           content: 'test',
           createdAt: DateTime.now().toUtc(),
           scheduledDate: existsDate,


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?

#113 의 일부 문제를 선행해결합니다.

## 어떻게 해결했나요?

- Todo 모델에서는 id가 `string`으로 지정되어있었는데, 테스트에서는 `int`로 지정되어있어 오류가 발생하고 있었습니다.
모델 수정에 앞서 우선 테스트에서 오류가 발생하지 않도록 테스트를 수정하였습니다. 구체적인 수정방향은 전체 회의 때 논의 후 결정합니다.
- svg의 import문을 해제하여 오류가 발생하지 않도록 하였습니다.
