### PR TITLE
todo를 최신순으로 정렬하도록 변경 

### DIFF
--- a/lib/models/todos.dart
+++ b/lib/models/todos.dart
@@ -152,9 +152,9 @@ class Todos extends ChangeNotifier {
       grouped[date]!.add(todo);
     }
 
-    // 각 그룹의 todo를 createdAt을 기준으로 정렬
+    // 각 그룹의 todo를 createdAt을 최신순으로 정렬
     for (final key in grouped.keys) {
-      grouped[key]!.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+      grouped[key]!.sort((a, b) => b.createdAt.compareTo(a.createdAt));
     }
 
     return grouped;


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?

#96 

초기 안드로이드 배포 테스트에서 앱을 킬때마다 투두 정렬이 달라진다는 제보를 받음. 
코드를 확인해보니 정렬 로직은 이미 들어가있으나(ab660922) 초기 안드로이드 배포 버전에 이 작업이 포함되지 않은 것으로 추측

이와 별개로 투두 입력 인풋이 위쪽에 있으므로 새로 입력한게 위쪽으로 배치되는게 자연스러워 보여서 정렬을 수정함

## 어떻게 해결했나요?

- todo를 최신순으로 정렬하도록 변경 

